### PR TITLE
Feat: Add HTTP strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,32 +6,34 @@
 
 1. Install the dependencies
 
-```
+```bash
 npm install @hyperjumptech/favicon-fetcher
 ```
 
 2. Use it in your code
 
 ```js
-const { getFavicon } = require('@hyperjumptech/favicon-fetcher') // CommonJS
-import { getFavicon } from '@hyperjumptech/favicon-fetcher' // ES6
+const { getFavicon, EStrategies } = require('@hyperjumptech/favicon-fetcher') // CommonJS
+import { getFavicon, EStrategies } from '@hyperjumptech/favicon-fetcher' // ES6
 
 const result1 = await getFavicon('https://www.google.com') // using all strategies
-console.log(result1) // returns a binary
+console.log(result1) // returns a binary or a URL
 
 const options = {
-  strategies: ['duckduckgo', 'default'], // use the DuckDuckGo API and default method
+  strategies: [EStrategies.duckduckgo, EStrategies.default], // use the DuckDuckGo API and default method
+  output: 'url', // can be 'url' or 'buffer'
 }
 
 const result2 = await getFavicon('https://www.google.com', options) // use some strategies
-console.log(result2) // returns a binary from either DuckDuckGo API or default method
+console.log(result2) // returns a binary or URL from either DuckDuckGo API or default method
 ```
 
 ## Options
 
-| Options    | Type       | Description                                                                                                                                                                   | Default                               |
-| ---------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
-| strategies | `string[]` | Define the strategies that will be used to fetch the favicon. Each strategies will be run sequentially. Currently available strategies are: `default`, `duckduckgo`, `google` | `['default', 'duckduckgo', 'google']` |
+| Options    | Type       | Description                                                                                                                                                                         | Default                                       |
+| ---------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| strategies | `string[]` | Define the strategies that will be used to fetch the favicon. Each strategy will be run sequentially. Currently available strategies are: `default`, `http`, `duckduckgo`, `google` | `['default', 'http', 'duckduckgo', 'google']` |
+| output     | `string`   | Define the output format of the fetched favicon. Can be either `url` or `buffer`.                                                                                                   | `'url'`                                       |
 
 ## Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,12 +6,13 @@
   "packages": {
     "": {
       "name": "@hyperjumptech/favicon-fetcher",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.2.3",
         "debug": "^4.3.4",
-        "node-fetch": "^2.6.11"
+        "node-fetch": "^2.6.11",
+        "node-html-parser": "^6.1.13"
       },
       "devDependencies": {
         "@types/jest": "^29.5.1",
@@ -1949,6 +1950,11 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2218,6 +2224,32 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -2357,6 +2389,57 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.405",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.405.tgz",
@@ -2380,6 +2463,17 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -3660,6 +3754,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "bin": {
+        "he": "bin/he"
       }
     },
     "node_modules/html-escaper": {
@@ -5099,6 +5201,15 @@
         }
       }
     },
+    "node_modules/node-html-parser": {
+      "version": "6.1.13",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.13.tgz",
+      "integrity": "sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -5130,6 +5241,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/object-inspect": {
@@ -7959,6 +8081,11 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -8149,6 +8276,23 @@
         "which": "^2.0.1"
       }
     },
+    "css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "requires": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      }
+    },
+    "css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw=="
+    },
     "damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -8253,6 +8397,39 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "requires": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      }
+    },
+    "domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
+    },
+    "domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "requires": {
+        "domelementtype": "^2.3.0"
+      }
+    },
+    "domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "requires": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      }
+    },
     "electron-to-chromium": {
       "version": "1.4.405",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.405.tgz",
@@ -8270,6 +8447,11 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -9194,6 +9376,11 @@
       "requires": {
         "has-symbols": "^1.0.2"
       }
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
     "html-escaper": {
       "version": "2.0.2",
@@ -10267,6 +10454,15 @@
         "whatwg-url": "^5.0.0"
       }
     },
+    "node-html-parser": {
+      "version": "6.1.13",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.13.tgz",
+      "integrity": "sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==",
+      "requires": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
+      }
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -10292,6 +10488,14 @@
       "dev": true,
       "requires": {
         "path-key": "^3.0.0"
+      }
+    },
+    "nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "requires": {
+        "boolbase": "^1.0.0"
       }
     },
     "object-inspect": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "@types/node": "^20.2.3",
     "debug": "^4.3.4",
-    "node-fetch": "^2.6.11"
+    "node-fetch": "^2.6.11",
+    "node-html-parser": "^6.1.13"
   }
 }

--- a/src/get-favicon.ts
+++ b/src/get-favicon.ts
@@ -1,59 +1,81 @@
 import fetch from 'node-fetch'
-import debug from 'debug'
+import { parse } from 'node-html-parser'
+import d from 'debug'
 
-const debugInstance = debug('favicon')
+// Initialize the debug instance
+const debug = d('favicon')
 
+// Enum to represent different favicon fetching strategies
 export enum EStrategies {
   default = 'default',
   duckduckgo = 'duckduckgo',
   google = 'google',
+  http = 'http',
 }
 
+// Interface for the options parameter
 interface IOptions {
   strategies?: EStrategies[]
   output?: 'buffer' | 'url'
 }
 
+// Interface for the strategy objects
 interface IStrategy {
   name: string
   url: string
 }
 
+// Function to fetch the favicon using different strategies
 export async function getFavicon(
   hostname: string,
   options?: IOptions,
-): Promise<Buffer | null> {
-  // This will fetch the favicon using three strategies:
-  // Using the /favicon.ico path, the DuckDuckGo API, and Google API
-  let icon
-  const output = options?.output || 'buffer'
+): Promise<Buffer | string | null> {
+  // Initialize the icon variable to null
+  let icon: Buffer | string | null = null
+  // Set the output format (default is 'url')
+  const output = options?.output || 'url'
 
-  // Define the used strategies
+  // Check whether the URL is valid
+  let url: string
+  try {
+    const isValidURL = new URL(hostname).href
+    if (isValidURL) {
+      url = hostname
+    }
+  } catch (e) {
+    throw new Error('The hostname provided is not a valid URL')
+  }
+
+  // Define the strategies to be used
   let strategies: IStrategy[] = []
+  // List of available strategies
   const availableStrategies: IStrategy[] = [
     {
       name: 'default',
-      url: `${hostname}/favicon.ico`,
+      url: `${url}/favicon.ico`,
+    },
+    {
+      name: 'http',
+      url,
     },
     {
       name: 'duckduckgo',
-      url: `https://icons.duckduckgo.com/ip3/${hostname}.ico`,
+      url: `https://icons.duckduckgo.com/ip3/${url}.ico`,
     },
     {
       name: 'google',
-      url: `https://s2.googleusercontent.com/s2/favicons?domain=${hostname}`,
+      url: `https://s2.googleusercontent.com/s2/favicons?domain=${url}`,
     },
   ]
 
-  // Handle the strategies options, meaning users only
-  // select some of the available strategies
+  // Handle the strategies options
   if (options?.strategies?.length > 0) {
-    debugInstance('Selected strategies:', options.strategies.join(','))
+    debug('Using selected strategies:', options.strategies.join(','))
 
     options.strategies.forEach(strategy => {
       if (!(strategy in EStrategies)) {
         // If the strategy is not available, skip it
-        debugInstance(`${strategy} strategy is not supported. Skipping`)
+        debug(`${strategy} strategy is not supported. Skipping`)
       } else {
         // If the strategy is available, use it
         const foundStrategy = availableStrategies.find(
@@ -63,49 +85,99 @@ export async function getFavicon(
       }
     })
   } else {
-    debugInstance('Using all strategies')
+    debug('Using all strategies: default, http, duckduckgo, and google')
 
+    // If no specific strategies are selected, use all available strategies
     strategies = availableStrategies
   }
 
-  // Loop API call to the strategy urls
+  // Loop through the strategy URLs
   for await (const strategy of strategies) {
     try {
-      debugInstance(`Fetching using ${strategy.name} strategy`)
+      debug(`Fetching using ${strategy.name} strategy`)
 
-      // Get the icon from the strategy url
+      // Fetch the icon from the strategy URL
       const response = await fetch(strategy.url)
-      const result = await response.arrayBuffer().then(ab => {
-        return Buffer.from(ab)
-      })
 
-      if (output === 'buffer') {
-        icon = result
-        break
+      switch (strategy.name) {
+        case 'http':
+          {
+            // Handle http strategy
+            debug('Fetching HTML...')
+            const html = await response.text()
+
+            debug('Parsing HTML...')
+            const root = parse(html)
+
+            debug(
+              'Getting the favicon URL from the <link rel="icon"> element...',
+            )
+            const head = root.querySelector('head')
+            const element = head.querySelector('link[rel="icon"]')
+            const iconPath = element.getAttribute('href')
+
+            debug('Check if the icon path is an absolute URL...')
+            let iconURL: string
+            try {
+              // Check if iconPath is an absolute URL
+              iconURL = new URL(iconPath, strategy.url).href
+            } catch (_) {
+              // Handle invalid URL cases
+              iconURL = `${strategy.url}${iconPath.replace(strategy.url, '')}`
+            }
+
+            debug(`Returning the favicon as ${output}...`)
+            if (output === 'buffer') {
+              // Get the image to buffer
+              const iconResponse = await fetch(iconURL)
+              const arrayBuffer = await iconResponse.arrayBuffer()
+              icon = Buffer.from(arrayBuffer)
+              break
+            }
+
+            if (output === 'url') {
+              // Set the icon URL
+              icon = iconURL
+              break
+            }
+          }
+          break
+
+        default: {
+          // Handle other strategies
+          debug(`Returning the favicon as ${output}...`)
+          const result = await response.arrayBuffer().then(ab => {
+            return Buffer.from(ab)
+          })
+
+          if (output === 'buffer') {
+            icon = result
+            break
+          }
+
+          if (output === 'url') {
+            icon = strategy.url
+            break
+          }
+        }
       }
 
-      if (output === 'url') {
-        icon = strategy.url
+      // If icon is found, break the loop
+      if (icon) {
         break
       }
-
-      // Else, use another strategy
-      continue
     } catch (_) {
-      // API error catched, use another strategy
+      // If an error occurs, continue with the next strategy
       continue
     }
   }
 
-  // After the loop, check if result has an icon
-  debugInstance('Icon result:', icon)
-
+  // After the loop, check if icon has been found
   if (icon) {
-    // If there is any icon, cache the icon
-    // Then return the icon
+    // If an icon is found, return it
     return icon
   } else {
-    // Else, return
+    // If no icon is found, return null
     return null
   }
 }

--- a/tests/get-favicon.test.ts
+++ b/tests/get-favicon.test.ts
@@ -7,40 +7,132 @@ beforeEach(() => {
 
 describe('Get favicon function', () => {
   it('should get the favicon correctly without options', async () => {
-    const result = await getFavicon('https://www.google.com')
+    const result = await getFavicon('https://github.com')
+
+    expect(result).not.toBeNull()
+    expect(result).toBe('https://github.com/favicon.ico')
+  })
+
+  it('should get the favicon correctly without options with buffer output', async () => {
+    const result = await getFavicon('https://github.com', {
+      output: 'buffer',
+    })
+
     expect(result).not.toBeNull()
   })
 
   it('should get the favicon correctly using the default strategy', async () => {
-    const result = await getFavicon('https://www.google.com', {
+    const result = await getFavicon('https://github.com', {
       strategies: ['default' as EStrategies],
     })
+
+    expect(result).not.toBeNull()
+    expect(result).toBe('https://github.com/favicon.ico')
+  })
+
+  it('should get the favicon correctly using the default strategy with buffer output', async () => {
+    const result = await getFavicon('https://github.com', {
+      strategies: ['default' as EStrategies],
+      output: 'buffer',
+    })
+
+    expect(result).not.toBeNull()
+  })
+
+  it('should get the favicon correctly using the http strategy', async () => {
+    const result = await getFavicon('https://github.com', {
+      strategies: ['http' as EStrategies],
+    })
+
+    expect(result).not.toBeNull()
+    expect(result).toBe('https://github.githubassets.com/favicons/favicon.svg')
+  })
+
+  it('should get the favicon correctly using the http strategy with buffer output', async () => {
+    const result = await getFavicon('https://github.com', {
+      strategies: ['http' as EStrategies],
+      output: 'buffer',
+    })
+
     expect(result).not.toBeNull()
   })
 
   it('should get the favicon correctly using the duckduckgo strategy', async () => {
-    const result = await getFavicon('https://www.google.com', {
+    const result = await getFavicon('https://github.com', {
       strategies: ['duckduckgo' as EStrategies],
     })
+
+    expect(result).not.toBeNull()
+    expect(result).toBe(
+      'https://icons.duckduckgo.com/ip3/https://github.com.ico',
+    )
+  })
+
+  it('should get the favicon correctly using the duckduckgo strategy with buffer output', async () => {
+    const result = await getFavicon('https://github.com', {
+      strategies: ['duckduckgo' as EStrategies],
+      output: 'buffer',
+    })
+
     expect(result).not.toBeNull()
   })
 
   it('should get the favicon correctly using the google strategy', async () => {
-    const result = await getFavicon('https://www.google.com', {
+    const result = await getFavicon('https://github.com', {
       strategies: ['google' as EStrategies],
     })
+
+    expect(result).not.toBeNull()
+    expect(result).toBe(
+      'https://s2.googleusercontent.com/s2/favicons?domain=https://github.com',
+    )
+  })
+
+  it('should get the favicon correctly using the google strategy with buffer output', async () => {
+    const result = await getFavicon('https://github.com', {
+      strategies: ['google' as EStrategies],
+      output: 'buffer',
+    })
+
     expect(result).not.toBeNull()
   })
 
   it('should not get the favicon correctly using unsupported strategy', async () => {
-    const result = await getFavicon('https://www.google.com', {
+    const result = await getFavicon('https://github.com', {
       strategies: ['bing' as EStrategies],
     })
+
+    expect(result).toBeNull()
+  })
+
+  it('should not get the favicon correctly using unsupported strategy with buffer output', async () => {
+    const result = await getFavicon('https://github.com', {
+      strategies: ['bing' as EStrategies],
+      output: 'buffer',
+    })
+
     expect(result).toBeNull()
   })
 
   it('should not get the favicon correctly because of bad URL', async () => {
-    const result = await getFavicon('ww.goo.gle')
-    expect(result).not.toBeNull()
+    try {
+      await getFavicon('nicelydone')
+      // If the function doesn't throw an error, fail the test
+      expect(true).toBe(false)
+    } catch (error) {
+      expect(error.message).toBe('The hostname provided is not a valid URL')
+    }
+  })
+
+  it('should not get the favicon correctly because of bad URL with buffer output', async () => {
+    try {
+      await getFavicon('nicelydone', {
+        output: 'buffer',
+      })
+      // If the function doesn't throw an error, fail the test
+      expect(true).toBe(false)
+    } catch (error) {
+      expect(error.message).toBe('The hostname provided is not a valid URL')
+    }
   })
 })


### PR DESCRIPTION
This PR adds a HTTP strategy.

The idea is to fetch the document from the target URL, and parse the HTML using node-html-parser. Then, we can get the icon URL from the href attribute of `<link rel="icon">` element.
