### PR TITLE
Fix: HTTP strategy for absolute icon paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Favicon Fetcher
 
-`favicon-fetcher` is a utility to fetch a website's favicon by using multiple strategies (the favicon.ico method, the DuckDuckGo API method, and the Google API method).
+`favicon-fetcher` is a utility to fetch a website's favicon by using multiple strategies. By default, it will fetch the `href` attribute of the first `<link rel="icon">` element in the target's HTML file.
 
 ## How to Use
 
@@ -21,7 +21,7 @@ console.log(result1) // returns a binary or a URL
 
 const options = {
   strategies: [EStrategies.duckduckgo, EStrategies.default], // use the DuckDuckGo API and default method
-  output: 'url', // can be 'url' or 'buffer'
+  output: 'url' // can be 'url' or 'buffer'
 }
 
 const result2 = await getFavicon('https://www.google.com', options) // use some strategies
@@ -30,10 +30,10 @@ console.log(result2) // returns a binary or URL from either DuckDuckGo API or de
 
 ## Options
 
-| Options    | Type       | Description                                                                                                                                                                         | Default                                       |
-| ---------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
-| strategies | `string[]` | Define the strategies that will be used to fetch the favicon. Each strategy will be run sequentially. Currently available strategies are: `default`, `http`, `duckduckgo`, `google` | `['default', 'http', 'duckduckgo', 'google']` |
-| output     | `string`   | Define the output format of the fetched favicon. Can be either `url` or `buffer`.                                                                                                   | `'url'`                                       |
+| Options    | Type       | Description                                                                                                                                                                                                                           | Default                                       |
+| ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| strategies | `string[]` | Define the strategies that will be used to fetch the favicon. Each strategy will be run sequentially. Currently available strategies are: `http`, `duckduckgo`, `google`, and `default`. Strategies defined will be run sequentially. | `['http', 'duckduckgo', 'google', 'default']` |
+| output     | `string`   | Define the output format of the fetched favicon. Can be either `url` or `buffer`. URL will return the favicon URL, buffer will return the image of the favicon                                                                        | `'url'`                                       |
 
 ## Contributing
 

--- a/src/get-favicon.ts
+++ b/src/get-favicon.ts
@@ -1,6 +1,6 @@
 import fetch from 'node-fetch'
-import d from 'debug'
 import { handleHttpStrategy, handleOtherStrategies } from './handlers'
+import d from 'debug'
 
 // Initialize the debug instance
 const debug = d('favicon')
@@ -58,13 +58,13 @@ export async function getFavicon(
 
   // Define available strategies for fetching the favicon
   const availableStrategies: IStrategy[] = [
-    { name: 'default', url: `${url}/favicon.ico` },
     { name: 'http', url },
     { name: 'duckduckgo', url: `https://icons.duckduckgo.com/ip3/${url}.ico` },
     {
       name: 'google',
       url: `https://s2.googleusercontent.com/s2/favicons?domain=${url}`
-    }
+    },
+    { name: 'default', url: `${url}/favicon.ico` }
   ]
 
   // Filter strategies based on options provided

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -25,14 +25,10 @@ export async function handleHttpStrategy(
     ?.getAttribute('href')
   if (!iconPath) return null
 
-  let iconURL: string
-  try {
-    const isAbsoluteURL = new URL(iconPath)
-    if (isAbsoluteURL) {
-      iconURL = isAbsoluteURL.href
-    }
-  } catch (e) {
-    iconURL = `${baseUrl}${iconPath}`
+  let iconURL: string = `${baseUrl}${iconPath.replace(baseUrl, '')}`
+  const isAbsoluteURL = new URL(iconPath, baseUrl)
+  if (isAbsoluteURL) {
+    iconURL = new URL(iconPath, baseUrl).href
   }
 
   if (output === 'buffer') {

--- a/tests/get-favicon.test.ts
+++ b/tests/get-favicon.test.ts
@@ -14,12 +14,12 @@ describe('Get favicon function', () => {
     const result = await getFavicon('https://github.com')
 
     expect(result).not.toBeNull()
-    expect(result).toBe('https://github.com/favicon.ico')
+    expect(result).toBe('https://github.githubassets.com/favicons/favicon.svg')
   })
 
   it('should get the favicon correctly without options with buffer output', async () => {
     const result = await getFavicon('https://github.com', {
-      output: 'buffer',
+      output: 'buffer'
     })
 
     expect(result).not.toBeNull()
@@ -27,7 +27,7 @@ describe('Get favicon function', () => {
 
   it('should get the favicon correctly using the default strategy', async () => {
     const result = await getFavicon('https://github.com', {
-      strategies: ['default' as EStrategies],
+      strategies: ['default' as EStrategies]
     })
 
     expect(result).not.toBeNull()
@@ -37,7 +37,7 @@ describe('Get favicon function', () => {
   it('should get the favicon correctly using the default strategy with buffer output', async () => {
     const result = await getFavicon('https://github.com', {
       strategies: ['default' as EStrategies],
-      output: 'buffer',
+      output: 'buffer'
     })
 
     expect(result).not.toBeNull()
@@ -45,7 +45,7 @@ describe('Get favicon function', () => {
 
   it('should get the favicon correctly using the http strategy', async () => {
     const result = await getFavicon('https://github.com', {
-      strategies: ['http' as EStrategies],
+      strategies: ['http' as EStrategies]
     })
 
     expect(result).not.toBeNull()
@@ -55,7 +55,7 @@ describe('Get favicon function', () => {
   it('should get the favicon correctly using the http strategy with buffer output', async () => {
     const result = await getFavicon('https://github.com', {
       strategies: ['http' as EStrategies],
-      output: 'buffer',
+      output: 'buffer'
     })
 
     expect(result).not.toBeNull()
@@ -63,19 +63,19 @@ describe('Get favicon function', () => {
 
   it('should get the favicon correctly using the duckduckgo strategy', async () => {
     const result = await getFavicon('https://github.com', {
-      strategies: ['duckduckgo' as EStrategies],
+      strategies: ['duckduckgo' as EStrategies]
     })
 
     expect(result).not.toBeNull()
     expect(result).toBe(
-      'https://icons.duckduckgo.com/ip3/https://github.com.ico',
+      'https://icons.duckduckgo.com/ip3/https://github.com.ico'
     )
   })
 
   it('should get the favicon correctly using the duckduckgo strategy with buffer output', async () => {
     const result = await getFavicon('https://github.com', {
       strategies: ['duckduckgo' as EStrategies],
-      output: 'buffer',
+      output: 'buffer'
     })
 
     expect(result).not.toBeNull()
@@ -83,19 +83,19 @@ describe('Get favicon function', () => {
 
   it('should get the favicon correctly using the google strategy', async () => {
     const result = await getFavicon('https://github.com', {
-      strategies: ['google' as EStrategies],
+      strategies: ['google' as EStrategies]
     })
 
     expect(result).not.toBeNull()
     expect(result).toBe(
-      'https://s2.googleusercontent.com/s2/favicons?domain=https://github.com',
+      'https://s2.googleusercontent.com/s2/favicons?domain=https://github.com'
     )
   })
 
   it('should get the favicon correctly using the google strategy with buffer output', async () => {
     const result = await getFavicon('https://github.com', {
       strategies: ['google' as EStrategies],
-      output: 'buffer',
+      output: 'buffer'
     })
 
     expect(result).not.toBeNull()
@@ -103,7 +103,7 @@ describe('Get favicon function', () => {
 
   it('should not get the favicon correctly using unsupported strategy', async () => {
     const result = await getFavicon('https://github.com', {
-      strategies: ['bing' as EStrategies],
+      strategies: ['bing' as EStrategies]
     })
 
     expect(result).toBeNull()
@@ -112,7 +112,7 @@ describe('Get favicon function', () => {
   it('should not get the favicon correctly using unsupported strategy with buffer output', async () => {
     const result = await getFavicon('https://github.com', {
       strategies: ['bing' as EStrategies],
-      output: 'buffer',
+      output: 'buffer'
     })
 
     expect(result).toBeNull()
@@ -131,7 +131,7 @@ describe('Get favicon function', () => {
   it('should not get the favicon correctly because of bad URL with buffer output', async () => {
     try {
       await getFavicon('nicelydone', {
-        output: 'buffer',
+        output: 'buffer'
       })
       // If the function doesn't throw an error, fail the test
       expect(true).toBe(false)
@@ -145,7 +145,7 @@ describe('Get favicon function', () => {
 
     const result = await getFavicon('https://github.com', {
       strategies: ['http' as EStrategies],
-      output: 'buffer',
+      output: 'buffer'
     })
 
     // Check that result is null because of fetch error

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -15,7 +15,7 @@ describe('handleHttpStrategy', () => {
     const result = await handleHttpStrategy(
       response,
       'http://example.com',
-      'url',
+      'url'
     )
     expect(result).toBeNull()
   })
@@ -25,31 +25,31 @@ describe('handleHttpStrategy', () => {
     const result = await handleHttpStrategy(
       response,
       'http://example.com',
-      'url',
+      'url'
     )
     expect(result).toBeNull()
   })
 
   it('should return icon URL for relative path', async () => {
     const response = new Response(
-      '<html><head><link rel="icon" href="/favicon.ico"/></head><body></body></html>',
+      '<html><head><link rel="icon" href="/favicon.ico"/></head><body></body></html>'
     )
     const result = await handleHttpStrategy(
       response,
       'http://example.com',
-      'url',
+      'url'
     )
     expect(result).toBe('http://example.com/favicon.ico')
   })
 
   it('should return icon URL for absolute path', async () => {
     const response = new Response(
-      '<html><head><link rel="icon" href="http://example.com/favicon.ico"/></head><body></body></html>',
+      '<html><head><link rel="icon" href="http://example.com/favicon.ico"/></head><body></body></html>'
     )
     const result = await handleHttpStrategy(
       response,
       'http://example.com',
-      'url',
+      'url'
     )
     expect(result).toBe('http://example.com/favicon.ico')
   })
@@ -62,7 +62,7 @@ describe('handleOtherStrategies', () => {
     const result = await handleOtherStrategies(
       response,
       'http://example.com',
-      'buffer',
+      'buffer'
     )
 
     expect(result).toEqual(Buffer.from(arrayBuffer))
@@ -73,7 +73,7 @@ describe('handleOtherStrategies', () => {
     const result = await handleOtherStrategies(
       response,
       'http://example.com',
-      'url',
+      'url'
     )
 
     expect(result).toBe('http://example.com')


### PR DESCRIPTION
This PR fixes the HTTP strategy for absolute icon paths:

![image](https://github.com/hyperjumptech/favicon-fetcher/assets/16670475/bd5e2d6f-5233-405c-b144-ee12b2d3e3ca)

This PR also set the HTTP strategy as the default method